### PR TITLE
Add navigation to all components

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,12 +1,11 @@
+import 'react-native-gesture-handler';
 import React, { Component } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { Tweet } from '../components/Tweet/Tweet';
-import { Success } from '../components/Success/Success';
 import { registerRootComponent } from 'expo';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import 'react-native-gesture-handler';
 import Form from '../components/Form/Form.js';
+import Tweet from '../components/Tweet/Tweet';
+import Success from '../components/Success/Success';
 
 const Stack = createStackNavigator();
 
@@ -19,10 +18,11 @@ class App extends Component {
     return (
       <NavigationContainer>
         <Stack.Navigator screenOptions={{
-          headerShown: false
+          headerShown: true
         }}>
-          <Stack.Screen name="Form" component={Form}
-          />
+          <Stack.Screen name="Home" component={Form} />
+          <Stack.Screen name="Tweet" component={Tweet} />
+          <Stack.Screen name="Success" component={Success} />
         </Stack.Navigator>
       </NavigationContainer>
     );

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -10,6 +10,7 @@ class Form extends Component {
     }
 
   render() {
+    const { navigation } = this.props
     return (
       <View style={styles.container}>
         <Text style={styles.h1}>
@@ -27,7 +28,7 @@ class Form extends Component {
           <Image style={styles.icon} source={require('../../../assets/images/photo.png')}/>
           <Text style={styles.iconLabel}>Add Photo</Text>
         </View>
-        <TouchableOpacity style={styles.button}><Text style={styles.buttonLabel}>Submit</Text></TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={ () => navigation.navigate('Tweet') }><Text style={styles.buttonLabel}>Submit</Text></TouchableOpacity>
       </View>
     )
   }

--- a/src/components/Success/Success.js
+++ b/src/components/Success/Success.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View, TouchableOpacity, Image } from 'react-native';
 
-export const Success = () => {
+export const Success = ({ navigation }) => {
 
   return(
     <View style={styles.successContainer}>
@@ -9,7 +9,7 @@ export const Success = () => {
       <Text style={styles.messageText}>Form submitted and Tweet Posted</Text>
       <Image style={styles.img} source={require('../../../assets/images/completed-task.png')} />
       <Text style={styles.thanksText}>Thanks!</Text>
-      <TouchableOpacity style={styles.homeButton}>
+      <TouchableOpacity style={styles.homeButton} onPress={ () => navigation.navigate('Home') }>
         <Text style={styles.homeLabel}>Home</Text>
       </TouchableOpacity>
     </View>
@@ -64,3 +64,5 @@ const styles = StyleSheet.create({
     fontSize: 20
   }
 });
+
+export default Success;

--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View, TextInput, TouchableOpacity, Image } from 'react-native';
 
-export const Tweet = ({ description }) => {
+export const Tweet = ({ description, navigation }) => {
 
   const redCheck = <Image style={styles.img} source={require('../../../assets/images/confirm.png')} />
   const greenCheck = <Image style={styles.img} source={require('../../../assets/images/confirmTrue.png')} />
@@ -20,7 +20,7 @@ export const Tweet = ({ description }) => {
         >
         </TextInput>
       </View>
-      <TouchableOpacity style={styles.confirmButton}>
+      <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
         <Text style={styles.buttonLabel}>Submit</Text>
       </TouchableOpacity>
     </View>
@@ -79,3 +79,5 @@ const styles = StyleSheet.create({
     fontSize: 20
   }
 })
+
+export default Tweet;


### PR DESCRIPTION
## What does this PR do?
- Adds navigation to all components 
- Changes header to true which adds a back button to the header 

## How to test?
- run `git fetch`
- git checkout `navigation-two-gi`
- run `npm i`
- `expo start`
- You should be able to see the changes in your emulator, click a button to move to the next page. 

## Issues:
- This PR should close any issues pertaining to app navigation 
- The board has not been updated 

## Notes
- I have it set use the header that is given to us by react native, see if you like it. If not we can take it out.

Thanks!
@cammac60 