### PR TITLE
Add tweet via the browser 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6381,6 +6381,22 @@
         "react-google-maps": "^9.4.5"
       }
     },
+    "react-native-webview": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-8.1.2.tgz",
+      "integrity": "sha512-UnGQDttXcgp9JuexidYVu3KIQn1V9xG93yKIs7u6OMdORD5EM4lm7Z1fqqBa59LBeEii5M546kh1/rm0rDA0cA==",
+      "requires": {
+        "escape-string-regexp": "2.0.0",
+        "invariant": "2.2.4"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
     "react-native-web": "~0.11.7",
-    "react-native-web-maps": "^0.2.0"
+    "react-native-web-maps": "^0.2.0",
+    "react-native-webview": "^8.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, StyleSheet, Text, Linking, TextInput, Button, } from 'react-native';
+import { View, StyleSheet, Text, Linking, TextInput, Button, TouchableOpacity } from 'react-native';
 
 
 export default class Tweet extends Component {
@@ -46,22 +46,23 @@ export default class Tweet extends Component {
   };
 
   render() {
+    const { navigation, setDec } = this.props;
+    const { tweetContent, twitterViaAccount } = this.state;
+
     return (
       <View style={styles.container}>
-        <Text
-          style={{ textAlign: 'center', fontSize: 20, paddingVertical: 30 }}>
-          Submit A Tweet
-        </Text>
-        <Text style={{ marginTop: 20 }}>Enter Tweet Content</Text>
+        <Text style={styles.h1}>Submit A Tweet</Text>
+        <Text style={styles.inputLabel}>Enter Tweet Content</Text>
         <TextInput
-          value={this.state.tweetContent}
-          onChangeText={tweetContent => this.setState({ tweetContent })}
+          value={tweetContent}
+          onChangeText={tweetContent => this.setState({ tweetContent }, setDec(tweetContent))}
           placeholder={'Enter Tweet Content'}
+          maxLength='280'
           style={styles.input}
         />
-        <Text style={{ marginTop: 20 }}>Enter Twitter Account</Text>
+        <Text style={styles.inputLabel}>Tag Twitter Account</Text>
         <TextInput
-          value={this.state.twitterViaAccount}
+          value={twitterViaAccount}
           onChangeText={twitterViaAccount =>
             this.setState({ twitterViaAccount })
           }
@@ -71,6 +72,9 @@ export default class Tweet extends Component {
         <View style={{ marginTop: 20 }}>
           <Button onPress={this.tweetNow} title="Tweet Now" />
         </View>
+        <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
+          <Text style={styles.buttonLabel}>Skip Tweet</Text>
+        </TouchableOpacity>
       </View>
     );
   }
@@ -79,111 +83,45 @@ export default class Tweet extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: 50,
     padding: 30,
+    backgroundColor: '#ffffff'
+  },
+  h1: {
+    color: '#3976EA',
+    fontSize: 45,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    textAlign: 'center', 
+    fontSize: 40, 
   },
   input: {
+    borderColor: 'gray',
+    lineHeight: 1,
+    borderWidth: 1,
     width: '100%',
-    height: 44,
-    padding: 10,
-    backgroundColor: '#D3D3D3',
+    height: 150,
+    padding: 5,
+    paddingTop: 0,
   },
+  inputLabel: {
+    color: '#3976EA',
+    fontSize: 18,
+    marginTop: 20, 
+    marginBottom: 8
+  },
+  confirmButton: {
+    alignItems: 'center',
+    backgroundColor: '#3976EA',
+    borderRadius: 20,
+    height: 40,
+    justifyContent: 'center',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    marginTop: 35,
+    width: '50%',
+  },
+  buttonLabel: {
+    color: '#FFFFFF',
+    fontSize: 20
+  }
 });
-
-
-
-
-
-
-// export const Tweet = ({ desc, navigation, setDesc }) => {
-
-//   const redCheck = <Image style={styles.img} source={require('../../../assets/images/confirm.png')} />
-//   const greenCheck = <Image style={styles.img} source={require('../../../assets/images/confirmTrue.png')} />
-
-//   return (
-//     <View style={styles.tweetContainer}>
-//       <Text style={styles.headerText}>Tweet the Issue:</Text>
-//       {/* { desc ? greenCheck : redCheck } */}
-//       <View style={styles.inputArea}>
-//         <WebView
-//           originWhitelist={['*']}
-//           source={{ uri: 'https://twitter.com/intent/tweet' }}
-//           style={styles.window}
-//           useWebKit={true}
-          
-//         />
-//         <Text style={styles.tweetLabel}>Your Tweet:</Text>
-//         <TextInput
-//           multiline
-//           maxLength='280'
-//           style={styles.tweetInput}
-//           placeholder='Your Tweet'
-//           value={desc}
-//           onChangeText={text => setDesc(text)}
-//         >
-//         </TextInput>
-//       </View>
-      // <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
-      //   <Text style={styles.buttonLabel}>Submit</Text>
-      // </TouchableOpacity>
-//     </View>
-//   )
-// };
-
-// const styles = StyleSheet.create({
-//   tweetContainer: {
-//     alignItems: 'center',
-//     backgroundColor: '#fff',
-//     flex: 1,
-//     justifyContent: 'space-between',
-//     padding: 1,
-//     width: '100%',
-//   },
-//   headerText: {
-//     color: '#3976EA',
-//     fontSize: 35,
-//     marginTop: 5,
-//   },
-//   inputArea: {
-//     flex: 1,
-//     marginTop: 10,
-//     width: '90%',
-//   },
-//   window: {
-//     height: '100%',
-//     marginBottom: 5,
-//     width: '100%',
-//   },
-//   tweetLabel: {
-//     color: '#3976EA',
-//     fontSize: 20,
-//     paddingBottom: 10,
-//   },
-//   tweetInput: {
-//     borderColor: 'gray',
-//     borderWidth: 1,
-//     height: 150,
-//     padding: 10,
-//     width: '100%',
-//   },
-//   img: {
-//     height: 100,
-//     marginTop: 10,
-//     width: 100,
-//   },
-//   confirmButton: {
-//     alignItems: 'center',
-//     backgroundColor: '#3976EA',
-//     borderRadius: 20,
-//     height: 40,
-//     justifyContent: 'center',
-//     marginLeft: 'auto',
-//     marginRight: 'auto',
-//     marginBottom: 35,
-//     width: '50%',
-//   },
-//   buttonLabel: {
-//     color: '#FFFFFF',
-//     fontSize: 20
-//   }
-// })

--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, StyleSheet, Text, Linking, TextInput, Button, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, Linking, TextInput, TouchableOpacity } from 'react-native';
 
 
 export default class Tweet extends Component {
@@ -46,7 +46,7 @@ export default class Tweet extends Component {
   };
 
   render() {
-    const { navigation, setDec } = this.props;
+    const { navigation, setDesc } = this.props;
     const { tweetContent, twitterViaAccount } = this.state;
 
     return (
@@ -55,9 +55,10 @@ export default class Tweet extends Component {
         <Text style={styles.inputLabel}>Enter Tweet Content</Text>
         <TextInput
           value={tweetContent}
-          onChangeText={tweetContent => this.setState({ tweetContent }, setDec(tweetContent))}
+          onChangeText={tweetContent => this.setState({ tweetContent }, setDesc(tweetContent))}
           placeholder={'Enter Tweet Content'}
           maxLength='280'
+          multiline
           style={styles.input}
         />
         <Text style={styles.inputLabel}>Tag Twitter Account</Text>
@@ -69,8 +70,10 @@ export default class Tweet extends Component {
           placeholder={'Enter Via Account'}
           style={styles.input}
         />
-        <View style={{ marginTop: 20 }}>
-          <Button onPress={this.tweetNow} title="Tweet Now" />
+        <View style={{ marginTop: 15 }}>
+          <TouchableOpacity style={styles.tweetBtn} onPress={this.tweetNow} title="Tweet">
+            <Text style={styles.tweetLabel}>Tweet</Text>
+          </TouchableOpacity>
         </View>
         <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
           <Text style={styles.buttonLabel}>Skip Tweet</Text>
@@ -88,26 +91,38 @@ const styles = StyleSheet.create({
   },
   h1: {
     color: '#3976EA',
-    fontSize: 45,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    textAlign: 'center', 
     fontSize: 40, 
+    textAlign: 'center', 
   },
   input: {
     borderColor: 'gray',
-    lineHeight: 1,
     borderWidth: 1,
-    width: '100%',
     height: 150,
-    padding: 5,
-    paddingTop: 0,
+    paddingLeft: 10,
+    paddingBottom: 90,
+    width: '100%',
   },
   inputLabel: {
     color: '#3976EA',
+    textAlign: 'center', 
     fontSize: 18,
     marginTop: 20, 
     marginBottom: 8
+  },
+  tweetBtn: {
+    alignItems: 'center',
+    backgroundColor: '#3976EA',
+    borderRadius: 20,
+    height: 40,
+    justifyContent: 'center',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    marginTop: 35,
+    width: '50%',
+  },
+  tweetLabel: {
+    color: '#FFFFFF',
+    fontSize: 20
   },
   confirmButton: {
     alignItems: 'center',

--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -1,85 +1,188 @@
-import React from 'react';
-import { StyleSheet, Text, View, TextInput, TouchableOpacity, Image } from 'react-native';
+import React, { Component } from 'react';
+import { View, StyleSheet, Text, Linking, TextInput, Button, } from 'react-native';
 
-export const Tweet = ({ desc, navigation, setDesc }) => {
 
-  const redCheck = <Image style={styles.img} source={require('../../../assets/images/confirm.png')} />
-  const greenCheck = <Image style={styles.img} source={require('../../../assets/images/confirmTrue.png')} />
+export default class Tweet extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tweetContent: this.props.desc,
+      twitterViaAccount: 'Tweet311Denver',
+    };
+  }
+  
+  tweetNow = () => {
+    let twitterParameters = '';
+    let { tweetContent, twitterViaAccount } = this.state
 
-  return (
-    <View style={styles.tweetContainer}>
-      <Text style={styles.headerText}>Confirm Your Tweet:</Text>
-      { desc ? greenCheck : redCheck }
-      <View style={styles.inputArea}>
-        <Text style={styles.tweetLabel}>Your Tweet:</Text>
+    if (tweetContent != undefined) {
+      if (twitterParameters.includes('?') == false) {
+        twitterParameters =
+          twitterParameters + '?text=' + encodeURI(tweetContent);
+      } else {
+        twitterParameters =
+          twitterParameters + '&text=' + encodeURI(tweetContent);
+      }
+    }
+    if (twitterViaAccount != undefined) {
+      if (twitterParameters.includes('?') == false) {
+        twitterParameters =
+          twitterParameters + '?via=' + encodeURI(twitterViaAccount);
+      } else {
+        twitterParameters =
+          twitterParameters + '&via=' + encodeURI(twitterViaAccount);
+      }
+    }
+    let url = 'https://twitter.com/intent/tweet' + twitterParameters;
+
+    Linking.openURL(url)
+      .then(data => {
+        alert('Twitter Opened');
+      })
+      .catch(() => {
+        alert('Something went wrong');
+      });
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text
+          style={{ textAlign: 'center', fontSize: 20, paddingVertical: 30 }}>
+          Submit A Tweet
+        </Text>
+        <Text style={{ marginTop: 20 }}>Enter Tweet Content</Text>
         <TextInput
-          multiline
-          maxLength='280'
-          style={styles.tweetInput}
-          placeholder='Your Tweet'
-          value={desc}
-          onChangeText={text => setDesc(text)}
-        >
-        </TextInput>
+          value={this.state.tweetContent}
+          onChangeText={tweetContent => this.setState({ tweetContent })}
+          placeholder={'Enter Tweet Content'}
+          style={styles.input}
+        />
+        <Text style={{ marginTop: 20 }}>Enter Twitter Account</Text>
+        <TextInput
+          value={this.state.twitterViaAccount}
+          onChangeText={twitterViaAccount =>
+            this.setState({ twitterViaAccount })
+          }
+          placeholder={'Enter Via Account'}
+          style={styles.input}
+        />
+        <View style={{ marginTop: 20 }}>
+          <Button onPress={this.tweetNow} title="Tweet Now" />
+        </View>
       </View>
-      <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
-        <Text style={styles.buttonLabel}>Submit</Text>
-      </TouchableOpacity>
-    </View>
-  )
-};
+    );
+  }
+}
 
 const styles = StyleSheet.create({
-  tweetContainer: {
-    alignItems: 'center',
-    backgroundColor: '#fff',
+  container: {
     flex: 1,
-    justifyContent: 'space-between',
-    padding: 15,
-    width: '95%',
+    marginTop: 50,
+    padding: 30,
   },
-  headerText: {
-    color: '#3976EA',
-    fontSize: 35,
-    marginTop: 20,
-  },
-  inputArea: {
-    flex: 1,
-    marginTop: 70,
-    width: '90%',
-  },
-  tweetLabel: {
-    color: '#3976EA',
-    fontSize: 20,
-    paddingBottom: 10,
-  },
-  tweetInput: {
-    borderColor: 'gray',
-    borderWidth: 1,
-    height: 150,
-    padding: 10,
+  input: {
     width: '100%',
+    height: 44,
+    padding: 10,
+    backgroundColor: '#D3D3D3',
   },
-  img: {
-    height: 250,
-    marginTop: 70,
-    width: 250,
-  },
-  confirmButton: {
-    alignItems: 'center',
-    backgroundColor: '#3976EA',
-    borderRadius: 20,
-    height: 40,
-    justifyContent: 'center',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    marginBottom: 35,
-    width: '50%',
-  },
-  buttonLabel: {
-    color: '#FFFFFF',
-    fontSize: 20
-  }
-})
+});
 
-export default Tweet;
+
+
+
+
+
+// export const Tweet = ({ desc, navigation, setDesc }) => {
+
+//   const redCheck = <Image style={styles.img} source={require('../../../assets/images/confirm.png')} />
+//   const greenCheck = <Image style={styles.img} source={require('../../../assets/images/confirmTrue.png')} />
+
+//   return (
+//     <View style={styles.tweetContainer}>
+//       <Text style={styles.headerText}>Tweet the Issue:</Text>
+//       {/* { desc ? greenCheck : redCheck } */}
+//       <View style={styles.inputArea}>
+//         <WebView
+//           originWhitelist={['*']}
+//           source={{ uri: 'https://twitter.com/intent/tweet' }}
+//           style={styles.window}
+//           useWebKit={true}
+          
+//         />
+//         <Text style={styles.tweetLabel}>Your Tweet:</Text>
+//         <TextInput
+//           multiline
+//           maxLength='280'
+//           style={styles.tweetInput}
+//           placeholder='Your Tweet'
+//           value={desc}
+//           onChangeText={text => setDesc(text)}
+//         >
+//         </TextInput>
+//       </View>
+      // <TouchableOpacity style={styles.confirmButton} onPress={ () => navigation.navigate('Success') }>
+      //   <Text style={styles.buttonLabel}>Submit</Text>
+      // </TouchableOpacity>
+//     </View>
+//   )
+// };
+
+// const styles = StyleSheet.create({
+//   tweetContainer: {
+//     alignItems: 'center',
+//     backgroundColor: '#fff',
+//     flex: 1,
+//     justifyContent: 'space-between',
+//     padding: 1,
+//     width: '100%',
+//   },
+//   headerText: {
+//     color: '#3976EA',
+//     fontSize: 35,
+//     marginTop: 5,
+//   },
+//   inputArea: {
+//     flex: 1,
+//     marginTop: 10,
+//     width: '90%',
+//   },
+//   window: {
+//     height: '100%',
+//     marginBottom: 5,
+//     width: '100%',
+//   },
+//   tweetLabel: {
+//     color: '#3976EA',
+//     fontSize: 20,
+//     paddingBottom: 10,
+//   },
+//   tweetInput: {
+//     borderColor: 'gray',
+//     borderWidth: 1,
+//     height: 150,
+//     padding: 10,
+//     width: '100%',
+//   },
+//   img: {
+//     height: 100,
+//     marginTop: 10,
+//     width: 100,
+//   },
+//   confirmButton: {
+//     alignItems: 'center',
+//     backgroundColor: '#3976EA',
+//     borderRadius: 20,
+//     height: 40,
+//     justifyContent: 'center',
+//     marginLeft: 'auto',
+//     marginRight: 'auto',
+//     marginBottom: 35,
+//     width: '50%',
+//   },
+//   buttonLabel: {
+//     color: '#FFFFFF',
+//     fontSize: 20
+//   }
+// })

--- a/src/components/Tweet/Tweet.js
+++ b/src/components/Tweet/Tweet.js
@@ -13,7 +13,8 @@ export default class Tweet extends Component {
   
   tweetNow = () => {
     let twitterParameters = '';
-    let { tweetContent, twitterViaAccount } = this.state
+    const { tweetContent, twitterViaAccount } = this.state;
+    const { navigation } = this.props;
 
     if (tweetContent != undefined) {
       if (twitterParameters.includes('?') == false) {
@@ -37,7 +38,7 @@ export default class Tweet extends Component {
 
     Linking.openURL(url)
       .then(data => {
-        alert('Twitter Opened');
+        navigation.navigate('Success')
       })
       .catch(() => {
         alert('Something went wrong');


### PR DESCRIPTION
## What does this PR do?
- Adds a web browser feature to send a tweet 
- Adds a button for skipping the tweet all together
- Adds navigation between the components

## How to test?
- Pull down the chnages
- Run `npm start`
- Fill out the form
- You will see the tweet component has changed
- Test all button paths 

## Issues:
- This PR should close #8 
- The board has not been updated 

## Screenshots:
![Screen Shot 2020-02-23 at 4 30 55 PM](https://user-images.githubusercontent.com/48968224/75122358-dee74d00-5659-11ea-8a4a-c8c5dbb4169c.png)

## Notes:
- There are a few things to checkout here. We are using two method calls on one `onTextChange` and it seems to be working. State in app should be updating at this point. The button path on return now points back to `Success` but we can play with this also. Let me know if there is anything you think we should change before merging.

Thanks!
@cammac60 